### PR TITLE
Fix makefile using the wrong shared library name on Linux systems

### DIFF
--- a/scipy-cephes/Makefile
+++ b/scipy-cephes/Makefile
@@ -15,7 +15,7 @@ ifeq ($(OS),Windows_NT)
 	OUTPUT = libmd.dll
 else # UNIX, use uname to determine which one
 	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), LINUX)
+	ifeq ($(UNAME_S), Linux)
 		LDFLAGS = -lm
 		OUTPUT = libmd.so
 	endif


### PR DESCRIPTION
`uname -s` reports "Linux" not "LINUX". Without this patch, the shared library is given the wrong name and loading the library through cffi fails on Linux systems.