### PR TITLE
only print library build info when *compile-verbose*

### DIFF
--- a/cephes.asd
+++ b/cephes.asd
@@ -27,11 +27,11 @@
 				     #+(or windows win32) "dll"))
 	   (built (probe-file (namestring lib))))
       (if built
-	  (format *error-output* "Library ~S exists, skipping build" lib)
-	  (format *error-output* "Building ~S~%" lib))
+	      (format *compile-verbose* "Library ~S exists, skipping build" lib)
+	      (format *compile-verbose* "Building ~S~%" lib))
       (unless built
 	(chdir (native-namestring lib-dir))
-	(run-program "make" :output t)))))
+	(run-program "make" :output *compile-verbose*)))))
 
 (defsystem "cephes"
   :description "Wrapper for the Cephes Mathematical Library"

--- a/cephes.asd
+++ b/cephes.asd
@@ -19,19 +19,19 @@
     (let* ((lib-dir (system-relative-pathname "cephes" "scipy-cephes/"))
            (lib (make-pathname :directory (pathname-directory lib-dir)
                                :name #+(or (and unix (not darwin)) windows win32) "libmd"
-			       #+(and darwin arm64) "libmd-arm64"
-			       #+(and darwin x86-64) "libmd-x86-64"
-			       :device (pathname-device lib-dir)
+			                   #+(and darwin arm64) "libmd-arm64"
+			                   #+(and darwin x86-64) "libmd-x86-64"
+			                   :device (pathname-device lib-dir)
                                :type #+darwin "dylib"
-				     #+(and unix (not darwin)) "so"
-				     #+(or windows win32) "dll"))
-	   (built (probe-file (namestring lib))))
+				               #+(and unix (not darwin)) "so"
+				               #+(or windows win32) "dll"))
+	       (built (probe-file (namestring lib))))
       (if built
 	      (format *compile-verbose* "Library ~S exists, skipping build" lib)
 	      (format *compile-verbose* "Building ~S~%" lib))
       (unless built
-	(chdir (native-namestring lib-dir))
-	(run-program "make" :output *compile-verbose*)))))
+	    (chdir (native-namestring lib-dir))
+	    (run-program "make" :output *compile-verbose*)))))
 
 (defsystem "cephes"
   :description "Wrapper for the Cephes Mathematical Library"
@@ -41,7 +41,7 @@
   :depends-on ("cffi")
   :serial t
   :components (#-allegro (:module "libmd"
-			  :components ((:makefile "makefile")))
-	       (:file "package")
-	       (:file "init")
+			              :components ((:makefile "makefile")))
+	           (:file "package")
+	           (:file "init")
                (:file "cephes")))


### PR DESCRIPTION
*compile-verbose* provides a means to control the debugging information printed during the compile step. Using it here helps silence output when loading this library form quicklisp in a roswell CLI scripts.

My reason for wanting this is that i am writing CLI programs, sometimes they cause compilation of libraries during execution because i'm using quicklisp in the `.ros` files.  This library is one of the only ones that prints an output, and the only way a can silence it otherwise is to blackhole *error-output*, but i came across this *compile-verbose* variable and it looks like the right choice to control this behavior.

Another possible implementation of this would be to change the format function like this

```
(format *compile-verbose* "Library ~S exists, skipping build" lib)
```

I don't know if there was a specific reason for using *error-output*, but i'm happy to adjust the PR if needed.