### PR TITLE
Enable bsd build

### DIFF
--- a/cephes.asd
+++ b/cephes.asd
@@ -17,6 +17,8 @@
   (defmethod perform ((o load-op) (c makefile)) t)
   (defmethod perform ((o compile-op) (c makefile))
     (let* ((lib-dir (system-relative-pathname "cephes" "scipy-cephes/"))
+           (make-executable #+bsd "make" 
+                            #+(not bsd) "make")
            (lib (make-pathname :directory (pathname-directory lib-dir)
                                :name #+(or (and unix (not darwin)) windows win32) "libmd"
 			                   #+(and darwin arm64) "libmd-arm64"
@@ -31,7 +33,7 @@
 	      (format *compile-verbose* "Building ~S~%" lib))
       (unless built
 	    (chdir (native-namestring lib-dir))
-	    (run-program "make" :output *compile-verbose*)))))
+	    (run-program make-executable :output *compile-verbose*)))))
 
 (defsystem "cephes"
   :description "Wrapper for the Cephes Mathematical Library"

--- a/cephes.asd
+++ b/cephes.asd
@@ -17,7 +17,7 @@
   (defmethod perform ((o load-op) (c makefile)) t)
   (defmethod perform ((o compile-op) (c makefile))
     (let* ((lib-dir (system-relative-pathname "cephes" "scipy-cephes/"))
-           (make-executable #+bsd "make" 
+           (make-executable #+bsd "gmake" 
                             #+(not bsd) "make")
            (lib (make-pathname :directory (pathname-directory lib-dir)
                                :name #+(or (and unix (not darwin)) windows win32) "libmd"

--- a/scipy-cephes/Makefile
+++ b/scipy-cephes/Makefile
@@ -16,7 +16,9 @@ ifeq ($(OS),Windows_NT)
 else # UNIX, use uname to determine which one
 	UNAME_S := $(shell uname -s)
 	UNAME_M := $(shell uname -m)
-	ifeq ($(UNAME_S), Linux)
+    LNX_BSD := Linux FreeBSD OpeBSD
+    IS_LNX_OR_BSD := $(filter $(UNAME_S),$(LNX_BSD))
+	ifneq ($(IS_LNX_OR_BSD),)
 		LDFLAGS = -lm
 		OUTPUT = libmd.so
 	endif

--- a/scipy-cephes/Makefile
+++ b/scipy-cephes/Makefile
@@ -16,7 +16,7 @@ ifeq ($(OS),Windows_NT)
 else # UNIX, use uname to determine which one
 	UNAME_S := $(shell uname -s)
 	UNAME_M := $(shell uname -m)
-    LNX_BSD := Linux FreeBSD OpeBSD
+    LNX_BSD := Linux FreeBSD OpenBSD
     IS_LNX_OR_BSD := $(filter $(UNAME_S),$(LNX_BSD))
 	ifneq ($(IS_LNX_OR_BSD),)
 		LDFLAGS = -lm


### PR DESCRIPTION
This PR aims to enable building `libmd.so` shared object for `*BSD` platforms. 