### PR TITLE
Add support for loading libmd on FreeBSD Clozure CL

### DIFF
--- a/init.lisp
+++ b/init.lisp
@@ -9,6 +9,7 @@
 		#+x86-64 #.(merge-pathnames "scipy-cephes/libmd-x86-64.dylib" *compile-file-pathname*)
 		#+arm64 #.(merge-pathnames "scipy-cephes/libmd-arm64.dylib" *compile-file-pathname*)))
   (:unix (:or "libmd"
+			  "libmd.so"
               #.(merge-pathnames "scipy-cephes/libmd.so" *compile-file-pathname*)))
   (t (:default "libmd")))
 

--- a/init.lisp
+++ b/init.lisp
@@ -9,7 +9,7 @@
 		#+x86-64 #.(merge-pathnames "scipy-cephes/libmd-x86-64.dylib" *compile-file-pathname*)
 		#+arm64 #.(merge-pathnames "scipy-cephes/libmd-arm64.dylib" *compile-file-pathname*)))
   (:unix (:or "libmd"
-			  "libmd.so"
+			  "scipy-cephes/libmd.so"
               #.(merge-pathnames "scipy-cephes/libmd.so" *compile-file-pathname*)))
   (t (:default "libmd")))
 


### PR DESCRIPTION
Clozure CL on FreeBSD won't find the libmd.so unless there's an actual ".so" suffix. The library works on this combination flawlessly.